### PR TITLE
Enable SSH session for workflow if it fails

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           NGROK_REGION: eu
-          NGROK_TIMEOUT: 1800
+          NGROK_TIMEOUT: 180
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
   lint:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,14 @@ jobs:
         run: cargo build --all-features
       - name: Run tests
         run: cargo test
+      - name: Start SSH session
+        if: ${{ failure() }}
+        uses: luchihoratiu/debug-via-ssh@main
+        with:
+          NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+          NGROK_REGION: eu
+          NGROK_TIMEOUT: 1800
+          SSH_PASS: ${{ secrets.SSH_PASS }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enable SSH session for workflow if it fails, for further debugging or investigation.